### PR TITLE
Fix layers on JLCPCB

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: INTI-CMNB/KiBot@v2_dk7
+    - uses: INTI-CMNB/KiBot@v2_k7
       with:
         # kibot config file
         config: config.kibot.yaml

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -41,7 +41,15 @@ outputs:
       line_width: 0.1
       subtract_mask_from_silk: true
       inner_extension_pattern: '.gp%n'
-    layers: 'selected'
+    layers:
+      - copper
+      - F.SilkS
+      - B.SilkS
+      - F.Mask
+      - B.Mask
+      - F.Paste
+      - B.Paste
+      - Edge.Cuts
 
   - name: JLCPCB_drill
     comment: Drill files compatible with JLCPCB

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -40,7 +40,6 @@ outputs:
       use_gerber_net_attributes: false
       line_width: 0.1
       subtract_mask_from_silk: true
-      inner_extension_pattern: '.gp%n'
     layers:
       - copper
       - F.SilkS

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -40,6 +40,7 @@ outputs:
       use_gerber_net_attributes: false
       line_width: 0.1
       subtract_mask_from_silk: true
+      inner_extension_pattern: '.g%nl'
     layers:
       - copper
       - F.SilkS

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -40,7 +40,6 @@ outputs:
       use_gerber_net_attributes: false
       line_width: 0.1
       subtract_mask_from_silk: true
-      inner_extension_pattern: '.g%nl'
     layers:
       - copper
       - F.SilkS


### PR DESCRIPTION
https://jlcpcb.com/help/article/233-Suggested-Naming-Patterns

JLCPCB seems to have changed their suffix for inner files to not accept .gp1, .gp2 ... anymore, they recommend using .g2l, .g3l instead. But when removing the custom `inner_extension_pattern` it will export as .g2, .g3 which is accepted by JLCPCB.

![image](https://github.com/badgineer/MP2-ESC/assets/12410754/1358b15b-b53a-4ba8-9e04-dbca548d4be2)
![image](https://github.com/badgineer/MP2-ESC/assets/12410754/28851a01-8b6d-4f4b-9c62-8409a685bb1a)

I also tried using .g2l, .g3l as custom suffix, but it did not work out correctly, so we'll just rather stay with .g2, .g3 which works just fine as well and is probably the correct `protel_extensions`.
Also JLCPCB wants Edge_Cuts to be using .GKO instead.

Someone might confirm this first. I am getting confused which extension means what, it is not very clear to me, because every site says something else.

